### PR TITLE
chore: harden CI workflows — SHA-pin actions, least-privilege permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   test-backend:
     name: Backend Tests
@@ -14,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python 3.14
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.14'
           cache: 'pip'
@@ -50,7 +53,7 @@ jobs:
           timeout 10m pytest --cov=app --cov-report=term-missing --cov-report=xml --ignore=tests/test_api_events.py -v
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./backend/coverage.xml
           flags: backend
@@ -61,10 +64,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: '1.3.8'
 
@@ -89,7 +92,7 @@ jobs:
           bun run test:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./frontend/coverage/coverage-final.json
           flags: frontend
@@ -102,10 +105,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python 3.14
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.14'
           cache: 'pip'
@@ -117,7 +120,7 @@ jobs:
           pip install -e backend/
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: '1.3.8'
 
@@ -139,7 +142,7 @@ jobs:
           CI: true
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
@@ -147,7 +150,7 @@ jobs:
           retention-days: 14
 
       - name: Upload test results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-results
@@ -161,10 +164,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python 3.14
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.14'
           cache: 'pip'
@@ -176,7 +179,7 @@ jobs:
           pip install -e backend/
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: '1.3.8'
 
@@ -198,13 +201,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,12 +34,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     # Python setup
     - name: Set up Python 3.14
       if: matrix.language == 'python'
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -57,7 +57,7 @@ jobs:
     # JavaScript/TypeScript setup
     - name: Set up Bun
       if: matrix.language == 'javascript'
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       with:
         bun-version: '1.3.8'
 
@@ -69,7 +69,7 @@ jobs:
 
     # Initialize CodeQL
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
       with:
         languages: ${{ matrix.language }}
         queries: security-extended,security-and-quality
@@ -78,11 +78,11 @@ jobs:
 
     # Autobuild (works for Python and JavaScript without compilation)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4
 
     # Perform CodeQL Analysis
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
       with:
         category: "/language:${{ matrix.language }}"
         output: sarif-results
@@ -91,7 +91,7 @@ jobs:
     # Upload SARIF results as artifact (for local review)
     - name: Upload SARIF results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: codeql-results-${{ matrix.language }}
         path: sarif-results
@@ -100,7 +100,7 @@ jobs:
     # Filter results for PR comments (optional enhancement)
     - name: Filter SARIF for pull requests
       if: github.event_name == 'pull_request'
-      uses: advanced-security/filter-sarif@v1
+      uses: advanced-security/filter-sarif@f3b8118a9349d88f7b1c0c488476411145b6270d # v1
       with:
         patterns: |
           -**/*.test.js
@@ -119,7 +119,7 @@ jobs:
 
     steps:
     - name: Download SARIF results
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         path: sarif-results
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,13 +21,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
@@ -63,7 +63,7 @@ jobs:
         # continue-on-error: Sigstore/Rekor outages should not block deploys.
         if: github.event.repository.visibility == 'public'
         continue-on-error: true
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -54,7 +54,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           name: TideWatch v${{ steps.version.outputs.version }}
           body_path: release_notes.md


### PR DESCRIPTION
## Summary

- Pin all 17 GitHub Action references to full-length commit SHAs (prevents tag-manipulation supply-chain attacks, same vector as Trivy incident)
- Add `permissions: contents: read` to `ci.yml` (was missing, defaulted to broad write-all)
- No workflow logic changes — `dependabot-auto-merge.yml` already uses `gh pr merge --auto` correctly

## SHA Manifest

| Action | Tag | SHA | Type |
|--------|-----|-----|------|
| actions/checkout | v6 | `de0fac2e` | lightweight |
| actions/setup-python | v6 | `a309ff8b` | lightweight |
| actions/upload-artifact | v7 | `bbbca2dd` | lightweight |
| actions/download-artifact | v8 | `3e5f45b2` | lightweight |
| actions/attest-build-provenance | v4 | `a2bbfa25` | annotated (dereferenced) |
| codecov/codecov-action | v5 | `75cd1169` | lightweight |
| oven-sh/setup-bun | v2 | `0c5077e5` | lightweight |
| docker/setup-buildx-action | v3 | `8d2750c6` | lightweight |
| docker/build-push-action | v6 | `10e90e36` | lightweight |
| docker/login-action | v3 | `c94ce9fb` | lightweight |
| github/codeql-action/* | v4 | `c10b8064` | annotated (dereferenced) |
| advanced-security/filter-sarif | v1 | `f3b8118a` | lightweight |
| dependabot/fetch-metadata | v2 | `ffa630c6` | lightweight |
| softprops/action-gh-release | v2 | `153bb8e0` | lightweight |

## Validation

- [x] `actionlint` v1.7.12 — zero errors
- [x] `grep -rn 'uses:.*@v[0-9]'` — zero unpinned refs
- [x] Annotated tags dereferenced to commit SHAs via `git ls-remote --tags ... ^{}`

## Test plan

- [ ] CI passes: Backend Tests, Frontend Tests, E2E Tests, Docker Build Test, API Types Freshness
- [ ] CodeQL passes: Analyze (python), Analyze (javascript), Security Scan Summary
- [ ] Branch protection requires all checks before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)