### PR TITLE
fix(workflows): grant required permissions to reusable-workflow wrappers

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
 jobs:
   codeql:
     uses: homelabforge/shared-workflows/.github/workflows/codeql.yml@v1.0.0

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,6 +3,10 @@ name: Dependabot Auto-Merge
 on:
   pull_request:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   auto-merge:
     uses: homelabforge/shared-workflows/.github/workflows/dependabot-auto-merge.yml@v1.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,10 @@ on:
     tags: ['v*.*.*']
 
 permissions:
-  contents: read
+  contents: write
+  packages: write
+  id-token: write
+  attestations: write
 
 jobs:
   publish:


### PR DESCRIPTION
Fixes CodeQL + Dependabot startup_failure post-wrapper-conversion. Reusable workflows can't exceed caller's permissions; wrapper had to grant them explicitly.