### PR TITLE
chore(workflows): bump shared-workflows v1.1.0 → v1.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,6 @@ permissions:
 
 jobs:
   ci:
-    uses: homelabforge/shared-workflows/.github/workflows/python-react-ci.yml@v1.1.0
+    uses: homelabforge/shared-workflows/.github/workflows/python-react-ci.yml@v1.3.0
     with:
       security-tripwire-script: .github/scripts/security-tripwire.sh

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,6 @@ permissions:
 
 jobs:
   codeql:
-    uses: homelabforge/shared-workflows/.github/workflows/codeql.yml@v1.1.0
+    uses: homelabforge/shared-workflows/.github/workflows/codeql.yml@v1.3.0
     with:
       python-extension-pack: homelabforge/tidewatch-models

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,6 +9,6 @@ permissions:
 
 jobs:
   auto-merge:
-    uses: homelabforge/shared-workflows/.github/workflows/dependabot-auto-merge.yml@v1.1.0
+    uses: homelabforge/shared-workflows/.github/workflows/dependabot-auto-merge.yml@v1.3.0
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   publish:
-    uses: homelabforge/shared-workflows/.github/workflows/python-react-publish.yml@v1.1.0
+    uses: homelabforge/shared-workflows/.github/workflows/python-react-publish.yml@v1.3.0
     with:
       security-tripwire-script: .github/scripts/security-tripwire.sh
       image-name: homelabforge/tidewatch


### PR DESCRIPTION
## Summary
- Bumps `homelabforge/shared-workflows` from v1.1.0 to v1.3.0 across all 4 workflow files (`ci.yml`, `publish.yml`, `codeql.yml`, `dependabot-auto-merge.yml`).
- v1.3.0 moves the last 5 node20-runtime actions (docker/build-push, docker/login, docker/setup-buildx, softprops/action-gh-release, dependabot/fetch-metadata) to node24 majors. Required ahead of the **2026-09-16 Node 20 removal** from GitHub-hosted runners.

## Why now
- 2026-06-02: Node 24 becomes runner default — node20-pinned actions force-bumped (mostly transparent).
- 2026-09-16: Node 20 removed entirely — `runs.using: node20` actions hard-fail.

Bumping now eliminates the deprecation warnings and gets ahead of both deadlines.

## What v1.3.0 changed
Pure runtime bumps — no API/input changes. See the [v1.3.0 release notes](https://github.com/homelabforge/shared-workflows/releases/tag/v1.3.0) for the action-by-action diff.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, next push to main triggers `ci.yml` cleanly
- [ ] Next tag-triggered release (publish.yml) successfully builds + pushes to GHCR + creates GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)