### PR TITLE
chore(deps): sync uv.lock self-version 3.9.1 → 3.9.3

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -773,7 +773,7 @@ wheels = [
 
 [[package]]
 name = "tidewatch"
-version = "3.9.1"
+version = "3.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },


### PR DESCRIPTION
## Summary
Lockfile catch-up. `backend/pyproject.toml` moved to `3.9.3` across the v3.9.2 / v3.9.3 releases, but `backend/uv.lock` wasn't regenerated alongside the pyproject bumps and still pinned tidewatch's own editable package at `3.9.1`.

## Why CI didn't catch it
`uv sync --frozen` (used in the shared CI workflow) fails on dependency hash drift but not on a project self-version mismatch. So the lockfile drifted silently.

## Diff
1-line change: tidewatch's own `[[package]]` version inside the lockfile. No dependency changes.

## Test plan
- [ ] CI green (no behavior change expected)
- [ ] Future `uv sync --frozen` runs install editable tidewatch at 3.9.3 instead of 3.9.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)